### PR TITLE
Prevent Duplicate Processes from Triggering

### DIFF
--- a/handlers/trigger.js
+++ b/handlers/trigger.js
@@ -22,7 +22,7 @@ module.exports = {
    inputValidation: {
       key: { string: true, required: true },
       data: { object: true, required: true },
-      requestId: { string: true, required: false }, // Needed to prevent duplicates if the request is retried
+      requestID: { string: true, optional: true }, // Needed to prevent duplicates if the request is retried
       // email: { string: { email: true }, optional: true },
    },
 
@@ -48,9 +48,9 @@ module.exports = {
             AB.processes().forEach((p) => {
                var t = p.taskForTriggerKey(key);
                if (t) {
-                  const requestId = req.param("requestId");
-                  const instanceKey = requestId
-                     ? `${requestId}.${t.id}`
+                  const requestID = req.param("requestID");
+                  const instanceKey = requestID
+                     ? `${requestID}.${t.id}`
                      : undefined;
                   // allTriggers.push(retryTrigger(t, data, req));
                   allTriggers.push(

--- a/handlers/trigger.js
+++ b/handlers/trigger.js
@@ -22,7 +22,7 @@ module.exports = {
    inputValidation: {
       key: { string: true, required: true },
       data: { object: true, required: true },
-      // uuid: { string: { uuid: true }, required: true },
+      requestId: { string: true, required: false }, // Needed to prevent duplicates if the request is retried
       // email: { string: { email: true }, optional: true },
    },
 
@@ -48,8 +48,14 @@ module.exports = {
             AB.processes().forEach((p) => {
                var t = p.taskForTriggerKey(key);
                if (t) {
+                  const requestId = req.param("requestId");
+                  const instanceKey = requestId
+                     ? `${requestId}.${t.id}`
+                     : undefined;
                   // allTriggers.push(retryTrigger(t, data, req));
-                  allTriggers.push(req.retry(() => t.trigger(data, req)));
+                  allTriggers.push(
+                     req.retry(() => t.trigger(data, req, instanceKey))
+                  );
                }
             });
 


### PR DESCRIPTION
Currently we retry timed out requests 5 time. This includes the request to `process_manager.trigger`. If `process_manger` is overwhelmed this can cause requests to time out though they eventually get added. This results in 5 copies of a process running.

We can pass an unique `requestID` param to prevent these duplicates from being created. 

Will require adding a column `instanceKey` to the `SITE_PROCESS_INSTANCE` table with a unique constraint.

See also: https://github.com/digi-serve/appbuilder_platform_service/pull/47